### PR TITLE
fix: powerStateDidChange event returns object

### DIFF
--- a/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
+++ b/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java
@@ -122,7 +122,12 @@ public class RNDeviceModule extends ReactContextBaseJavaModule {
         Boolean powerSaveState = powerState.getBoolean(LOW_POWER_MODE);
 
         if(!mLastBatteryState.equalsIgnoreCase(batteryState) || mLastPowerSaveState != powerSaveState) {
-          sendEvent(getReactApplicationContext(), "RNDeviceInfo_powerStateDidChange", batteryState);
+          WritableMap updatedPowerState = Arguments.createMap();
+          updatedPowerState.putString(BATTERY_STATE, batteryState);
+          updatedPowerState.putDouble(BATTERY_LEVEL, batteryLevel);
+          updatedPowerState.putBoolean(LOW_POWER_MODE, powerSaveState);
+          
+          sendEvent(getReactApplicationContext(), "RNDeviceInfo_powerStateDidChange", updatedPowerState);
           mLastBatteryState = batteryState;
           mLastPowerSaveState = powerSaveState;
         }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #1651

I expected the `usePowerState` or `RNDeviceInfo_powerStateDidChange` to return a `powerState` :object, but it was only returning an object at first and then only the `batteryState` value afterwards.
I have modified it to always return an object.

According to the documentation, it is supposed to return a `powerState` object, so I made functional changes without modifying the documentation.

<!-- OR, if you're implementing a new feature: -->

Added `yourNewMethodName()` that allows ...

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [X] I have tested this on a device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
